### PR TITLE
Fix typo in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ og_image: "/images/plugins/turbot/slack-social-graphic.png"
 
 # Slack + Steampipe
 
-[Slack](https://slack.com/) s a messaging program designed specifically for the workplace.
+[Slack](https://slack.com/) is a messaging program designed specifically for the workplace.
 
 [Steampipe](https://steampipe.io) is an open source CLI to instantly query cloud APIs using SQL.
 


### PR DESCRIPTION
Missing letter in the word `is` following the link to Slack website.